### PR TITLE
fix: widen http dependency constraint to support versions 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 4.0.4 - 12/03/2026
+
+- Update constraint to avoid version conflicts in http and intl.
+
+
 # 4.0.3 - 20/11/2025
 
 ### Fix

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,9 +2,6 @@ PODS:
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -15,7 +12,6 @@ PODS:
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
@@ -24,8 +20,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
@@ -34,8 +28,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 30517025a2fecca2d72dac25f08abb5b9a8f1a56

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,16 @@
-import UIKit
 import Flutter
+import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -22,6 +24,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/example/lib/Providers/fs_data.dart
+++ b/example/lib/Providers/fs_data.dart
@@ -72,8 +72,7 @@ class UserData extends ChangeNotifier {
     "condition1": "segment",
     "bucketKeyFlutter": "Mercredi",
     "numericKeyFlutter": true,
-    "floatKeyFlutter": 12.5,
-    "nullKeyFlutter": Null
+    "floatKeyFlutter": 12.5
   };
   bool _hasConsented = true;
   bool _isAuthenticated = false;

--- a/example/lib/widgets/configuration.dart
+++ b/example/lib/widgets/configuration.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'package:flagship/cache/interface_cache.dart';
 import 'package:flagship/flagship.dart';
-import 'package:flagship/flagshipContext/flagship_context.dart';
 import 'package:flagship/flagship_config.dart';
 import 'package:flagship/hits/event.dart';
 import 'package:flagship/hits/item.dart';

--- a/lib/dataUsage/data_usage_tracking.dart
+++ b/lib/dataUsage/data_usage_tracking.dart
@@ -104,12 +104,20 @@ class DataUsageTracking {
 
   bool isTimeSlotValide() {
     try {
-      // Get the dates
-      DateTime startDate =
-          DateTime.parse(_singleton._troubleshooting?.startDate ?? "");
+      // Check if dates exist
+      String? startDateStr = _singleton._troubleshooting?.startDate;
+      String? endDateStr = _singleton._troubleshooting?.endDate;
 
-      DateTime endDate =
-          DateTime.parse(_singleton._troubleshooting?.endDate ?? "");
+      if (startDateStr == null ||
+          startDateStr.isEmpty ||
+          endDateStr == null ||
+          endDateStr.isEmpty) {
+        return false;
+      }
+
+      // Get the dates
+      DateTime startDate = DateTime.parse(startDateStr);
+      DateTime endDate = DateTime.parse(endDateStr);
 
       // Get the actual date
       DateTime actualDate = DateTime.now();

--- a/lib/flagship_version.dart
+++ b/lib/flagship_version.dart
@@ -1,2 +1,2 @@
 /// This file is automatically updated
-const FlagshipVersion = "4.0.3";
+const FlagshipVersion = "4.0.4";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_device_type: ^0.4.0
   http: ">=0.13.1 <2.0.0"
-  intl: ^0.17.0
+  intl: ">=0.17.0 <1.0.0"
   murmurhash: ^1.0.1
   path_provider: ^2.0.11
   pausable_timer: ^1.0.0+6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flagship
 description: Flutter SDK for Flagship Feature management & Experiment platform for modern engineering and product teams
-version: 4.0.3
+version: 4.0.4
 homepage: https://flagship.io
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_device_type: ^0.4.0
-  http: ^0.13.1
+  http: ">=0.13.1 <2.0.0"
   intl: ^0.17.0
   murmurhash: ^1.0.1
   path_provider: ^2.0.11


### PR DESCRIPTION
Update constraint from `^0.13.1` to `>=0.13.1 <2.0.0` to avoid version conflicts with client projects using http 1.x. The SDK only uses stable APIs (Client, get, post, Response) that are compatible across all these versions.